### PR TITLE
Migrate to none-ls since null-ls is archived

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -11,7 +11,7 @@ call plug#begin('~/.vim/bundle')
 Plug 'ggandor/leap.nvim'
 Plug 'tpope/vim-fugitive'
 Plug 'terrortylor/nvim-comment'
-Plug 'jose-elias-alvarez/null-ls.nvim'
+Plug 'nvimtools/none-ls.nvim'
 Plug 'nvim-lua/plenary.nvim' " dep for null-ls
 Plug 'nvim-lualine/lualine.nvim'
 Plug 'ishan9299/nvim-solarized-lua'
@@ -91,7 +91,7 @@ set clipboard+=unnamedplus
 "line numbers
 
 nnoremap <F11> :set relativenumber!<cr>
-set pastetoggle=<F12>
+nnoremap <silent> <F12> :set paste!<cr>
 
 " for C-like programming, have automatic indentation:
 augroup webcode

--- a/nvim/lua/config.lua
+++ b/nvim/lua/config.lua
@@ -133,6 +133,8 @@ cmp.setup.cmdline(':', {
 	})
 })
 
+vim.diagnostic.config({ virtual_text = true })
+
 -- Setup lspconfig.
 local capabilities = require('cmp_nvim_lsp').default_capabilities()
 

--- a/nvim/lua/config.lua
+++ b/nvim/lua/config.lua
@@ -24,7 +24,6 @@ require('fzf-lua').setup {
 null_ls.setup({
 	sources = {
 		null_ls.builtins.formatting.nginx_beautifier,
-		null_ls.builtins.formatting.trim_whitespace,
 		null_ls.builtins.formatting.shfmt,
 		null_ls.builtins.diagnostics.staticcheck,
 		null_ls.builtins.diagnostics.golangci_lint,


### PR DESCRIPTION
Som jag förstod det så gör inte trim_whitespace något längre.